### PR TITLE
Fix RTD build: bump deprecated ubuntu-20.04, add docs/requirements.txt

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.12"
 
 sphinx:
   configuration: docs/source/conf.py
@@ -12,3 +12,4 @@ python:
   install:
     - method: pip
       path: .
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-rtd-theme


### PR DESCRIPTION
## Summary
- `build.os: ubuntu-20.04` / Python 3.9 no longer matched `pyproject.toml`'s `requires-python` and ubuntu-20.04 is no longer a supported RTD image — the RTD build was failing outright.
- Sphinx/sphinx-rtd-theme are dev-group deps, not runtime ones, so `pip install .` alone never installed them; added `docs/requirements.txt` matching the rest of the fleet.
- Verified with a clean 3.11 venv + local `sphinx-build` (succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALX9XMNDZkm4rMDmXzfV34